### PR TITLE
delete compression in Log4net sanity test

### DIFF
--- a/src/IntegrationTests/Log4net/Log4netSanityTests.cs
+++ b/src/IntegrationTests/Log4net/Log4netSanityTests.cs
@@ -34,7 +34,6 @@ namespace Logzio.DotNet.IntegrationTests.Log4net
             var logzioAppender = new LogzioAppender();
             logzioAppender.AddToken("123456789");
             logzioAppender.AddListenerUrl(_dummy.DefaultUrl);
-            logzioAppender.AddCompression(true);
             logzioAppender.ActivateOptions();
             hierarchy.Root.AddAppender(logzioAppender);
             hierarchy.Configured = true;


### PR DESCRIPTION
Forgot to delete the compression from the sanity test.